### PR TITLE
Fix error in "all" configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = {
       }
     },
     all: {
-      plugin: [
+      plugins: [
         'react-perf'
       ],
       parserOptions: {


### PR DESCRIPTION
Hey, thanks for this great plugin!

I receive an error when I try to extend the `plugin:react-perf/all` ruleset.

```
Error: ESLint configuration in plugin:react-perf/all is invalid:
 - Unexpected top-level property "plugin".
```

Extending `plugin:react-perf/recommended` is successful, so I think the misnamed property is the only issue.

I'm using ESLint 4.11.0.