### PR TITLE
Catch arrow functions used as props

### DIFF
--- a/lib/rules/jsx-no-new-function-as-prop.js
+++ b/lib/rules/jsx-no-new-function-as-prop.js
@@ -6,14 +6,16 @@ module.exports = createRule(
   'Prevent `function` as JSX prop value',
   'JSX attribute values should not contain functions created in the same scope',
   function(node) {
-    if (node.type === 'FunctionExpression' || checkConstructor(node, 'Function'))
+    if (node.type === 'FunctionExpression' || checkConstructor(node, 'Function')) {
       return true
+    }
 
     // <Item onClick={this.clickHandler.bind(this)} />
     if (node.type === 'CallExpression' &&
       node.callee.property &&
-      node.callee.property.name === 'bind')
+      node.callee.property.name === 'bind') {
       return true
+    }
 
     return false
   })

--- a/lib/rules/jsx-no-new-function-as-prop.js
+++ b/lib/rules/jsx-no-new-function-as-prop.js
@@ -6,7 +6,9 @@ module.exports = createRule(
   'Prevent `function` as JSX prop value',
   'JSX attribute values should not contain functions created in the same scope',
   function(node) {
-    if (node.type === 'FunctionExpression' || checkConstructor(node, 'Function')) {
+    if (node.type === 'FunctionExpression' ||
+      node.type === 'ArrowFunctionExpression' ||
+      checkConstructor(node, 'Function')) {
       return true
     }
 

--- a/tests/lib/rules/jsx-no-new-function-as-prop.js
+++ b/tests/lib/rules/jsx-no-new-function-as-prop.js
@@ -27,7 +27,7 @@ var invalidNewExpressions = [
 })
 
 var invalidCallExpressions = [
-  {code: "<Item onClick={this.clickHandler.bind(this)} />", line: 1, column: 16}
+  {code: '<Item onClick={this.clickHandler.bind(this)} />', line: 1, column: 16}
 ].map(function({code, line, column}) {
   return {
     code,

--- a/tests/lib/rules/jsx-no-new-function-as-prop.js
+++ b/tests/lib/rules/jsx-no-new-function-as-prop.js
@@ -13,6 +13,19 @@ var invalidFunctionExpressions = [
   }
 })
 
+var invalidArrowFunctionExpressions = [
+  {code: '<Item prop={() => true} />', line: 1, column: 13}
+].map(function({code, line, column}) {
+  return {
+    code,
+    errors: [{
+      line,
+      column,
+      type: 'ArrowFunctionExpression'
+    }]
+  }
+})
+
 var invalidNewExpressions = [
   {code: "<Item prop={new Function('a', 'alert(a)')}/>", line: 1, column: 13}
 ].map(function({code, line, column}) {
@@ -51,6 +64,7 @@ module.exports = require('../utils/common').testRule(
   'FunctionExpression',
   [].concat(
     invalidFunctionExpressions,
+    invalidArrowFunctionExpressions,
     invalidNewExpressions,
     invalidCallExpressions),
   validExpressions)


### PR DESCRIPTION
Howdy!

Currently, the code

```jsx
<Item prop={function(){return true}} />
```

triggers the `no-new-function-as-prop` rule, but the (practically) equivalent code

```jsx
<Item prop={() => true} />
```

does not. This PR corrects the discrepancy.