### PR TITLE
allow for native elements to be ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Add `plugins` section and specify eslint-plugin-react-perf as a plugin.
 
 # Configuration
 
-Each eslint-plugin-react-perf rule supports configuration to control whether native elements (lower case first letter React components) are ignored.
+As of v3.3, each eslint-plugin-react-perf rule supports configuration to control whether native elements (lower case first letter React components) are ignored.
 
 With this configuration, all native elements are ignored for this rule:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-eslint-plugin-react-perf
-========================
+# eslint-plugin-react-perf
 
 Performance-minded React linting rules for ESLint (motivated by [esamatti](https://twitter.com/esamatti)'s post ["React.js pure render performance anti-pattern"](https://medium.com/@esamatti/react-js-pure-render-performance-anti-pattern-fb88c101332f)).
 
@@ -9,24 +8,50 @@ Performance-minded React linting rules for ESLint (motivated by [esamatti](https
 $ npm i eslint-plugin-react-perf
 ```
 
-# Configuration
-
 Add `plugins` section and specify eslint-plugin-react-perf as a plugin.
 
 ```json
 {
-  "plugins": [
-    "react-perf"
-  ]
+  "plugins": ["react-perf"]
 }
 ```
 
 # List of supported rules
 
-* [react-perf/jsx-no-new-object-as-prop](docs/rules/jsx-no-new-object-as-prop.md): Prevent `{...}` as JSX prop value
-* [react-perf/jsx-no-new-array-as-prop](docs/rules/jsx-no-new-array-as-prop.md): Prevent `[...]` as JSX prop value
-* [react-perf/jsx-no-new-function-as-prop](docs/rules/jsx-no-new-function-as-prop.md): Prevent `function` as JSX prop value
-* [react-perf/jsx-no-jsx-as-prop](docs/rules/jsx-no-jsx-as-prop.md): Prevent JSX as JSX prop value
+- [react-perf/jsx-no-new-object-as-prop](docs/rules/jsx-no-new-object-as-prop.md): Prevent `{...}` as JSX prop value
+- [react-perf/jsx-no-new-array-as-prop](docs/rules/jsx-no-new-array-as-prop.md): Prevent `[...]` as JSX prop value
+- [react-perf/jsx-no-new-function-as-prop](docs/rules/jsx-no-new-function-as-prop.md): Prevent `function` as JSX prop value
+- [react-perf/jsx-no-jsx-as-prop](docs/rules/jsx-no-jsx-as-prop.md): Prevent JSX as JSX prop value
+
+# Configuration
+
+Each eslint-plugin-react-perf rule supports configuration to control whether native elements (lower case first letter React components) are ignored.
+
+With this configuration, all native elements are ignored for this rule:
+
+```json
+{
+  "react-perf/jsx-no-new-object-as-prop": [
+    "error",
+    {
+      "nativeExcludes": "all"
+    }
+  ]
+}
+```
+
+With this configuration, the "style" attribute is ignored for native elements for this rule:
+
+```json
+{
+  "react-perf/jsx-no-new-object-as-prop": [
+    "error",
+    {
+      "nativeExcludes": ["style"]
+    }
+  ]
+}
+```
 
 ## Recommended
 
@@ -44,10 +69,10 @@ See [ESLint documentation](http://eslint.org/docs/user-guide/configuring#extendi
 
 The rules enabled in this configuration are:
 
-* [react-perf/jsx-no-new-object-as-prop](docs/rules/jsx-no-new-object-as-prop.md)
-* [react-perf/jsx-no-new-array-as-prop](docs/rules/jsx-no-new-array-as-prop.md)
-* [react-perf/jsx-no-new-function-as-prop](docs/rules/jsx-no-new-function-as-prop.md)
-* [react-perf/jsx-no-jsx-as-prop](docs/rules/jsx-no-jsx-as-prop.md)
+- [react-perf/jsx-no-new-object-as-prop](docs/rules/jsx-no-new-object-as-prop.md)
+- [react-perf/jsx-no-new-array-as-prop](docs/rules/jsx-no-new-array-as-prop.md)
+- [react-perf/jsx-no-new-function-as-prop](docs/rules/jsx-no-new-function-as-prop.md)
+- [react-perf/jsx-no-jsx-as-prop](docs/rules/jsx-no-jsx-as-prop.md)
 
 ## All
 
@@ -63,6 +88,7 @@ This plugin also exports an `all` configuration that includes every available ru
 ```
 
 # Test anti-patterns in runtime
+
 Try out [cvazac/test-ref-pattern](https://github.com/cvazac/test-ref-pattern).
 
 # License

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Add `plugins` section and specify eslint-plugin-react-perf as a plugin.
 
 # Configuration
 
-As of v3.3, each eslint-plugin-react-perf rule supports configuration to control whether native elements (lower case first letter React components) are ignored.
+As of v3.3.0, each eslint-plugin-react-perf rule supports configuration to control whether native elements (lower case first letter React components) are ignored.
 
 With this configuration, all native elements are ignored for this rule:
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ With this configuration, all native elements are ignored for this rule:
   "react-perf/jsx-no-new-object-as-prop": [
     "error",
     {
-      "nativeExcludes": "all"
+      "nativeAllowList": "all"
     }
   ]
 }
@@ -47,7 +47,7 @@ With this configuration, the "style" attribute is ignored for native elements fo
   "react-perf/jsx-no-new-object-as-prop": [
     "error",
     {
-      "nativeExcludes": ["style"]
+      "nativeAllowList": ["style"]
     }
   ]
 }

--- a/lib/utils/common.js
+++ b/lib/utils/common.js
@@ -6,31 +6,65 @@ function createRule(description, errorMessage, isViolation) {
       docs: {
         description,
         category: "",
-        recommended: true
+        recommended: true,
       },
-      schema: []
+      schema: [
+        {
+          additionalProperties: false,
+          properties: {
+            nativeExcludes: {
+              oneOf: [
+                {
+                  enum: ["all"],
+                },
+                {
+                  type: "array",
+                  items: {
+                    type: "string",
+                  },
+                },
+              ],
+            },
+          },
+          type: "object",
+        },
+      ],
     },
 
-    create: function(context) {
+    create: function (context) {
+      const { options } = context;
+      const { nativeExcludes } = options[0] || {};
       return {
-        JSXAttribute: function(node) {
+        JSXAttribute: function (node) {
           if (!node.value || node.value.type !== "JSXExpressionContainer") {
+            return;
+          }
+          if (
+            isNativeElement(node) &&
+            (nativeExcludes === "all" ||
+              (Array.isArray(nativeExcludes) &&
+                nativeExcludes.find(function (nativeExclude) {
+                  return (
+                    node.name.name.toLowerCase() === nativeExclude.toLowerCase()
+                  );
+                })))
+          ) {
             return;
           }
 
           var violationFound = false;
-          findRelevantNodes(context, node.value.expression).forEach(function(
+          findRelevantNodes(context, node.value.expression).forEach(function (
             node
           ) {
-            if (isViolation(node)) {
+            if (isViolation(node, nativeExcludes)) {
               violationFound = true;
               context.report(node, errorMessage);
             }
           });
           return violationFound;
-        }
+        },
       };
-    }
+    },
   };
 }
 
@@ -41,11 +75,11 @@ function findRelevantNodes(context, node) {
       return;
     }
     if (node.type === "Identifier") {
-      var variable = context.getScope().variables.find(function(variable) {
+      var variable = context.getScope().variables.find(function (variable) {
         return variable.name === node.name;
       });
       if (variable) {
-        variable.references.forEach(function(reference) {
+        variable.references.forEach(function (reference) {
           if (!reference.identifier.parent) return;
           switch (reference.identifier.parent.type) {
             case "AssignmentExpression":
@@ -88,7 +122,16 @@ function checkConstructor(node, className) {
   }
 }
 
+function isNativeElement(node) {
+  if (node.parent.name.type !== "JSXIdentifier") {
+    return false;
+  }
+  const nodeName = node.parent.name.name;
+  const firstChar = nodeName.charAt(0);
+  return firstChar === firstChar.toLowerCase();
+}
+
 module.exports = {
   createRule,
-  checkConstructor
+  checkConstructor,
 };

--- a/lib/utils/common.js
+++ b/lib/utils/common.js
@@ -12,7 +12,7 @@ function createRule(description, errorMessage, isViolation) {
         {
           additionalProperties: false,
           properties: {
-            nativeExcludes: {
+            nativeAllowList: {
               oneOf: [
                 {
                   enum: ["all"],
@@ -33,7 +33,7 @@ function createRule(description, errorMessage, isViolation) {
 
     create: function (context) {
       const { options } = context;
-      const { nativeExcludes } = options[0] || {};
+      const { nativeAllowList } = options[0] || {};
       return {
         JSXAttribute: function (node) {
           if (!node.value || node.value.type !== "JSXExpressionContainer") {
@@ -41,9 +41,9 @@ function createRule(description, errorMessage, isViolation) {
           }
           if (
             isNativeElement(node) &&
-            (nativeExcludes === "all" ||
-              (Array.isArray(nativeExcludes) &&
-                nativeExcludes.find(function (nativeExclude) {
+            (nativeAllowList === "all" ||
+              (Array.isArray(nativeAllowList) &&
+                nativeAllowList.find(function (nativeExclude) {
                   return (
                     node.name.name.toLowerCase() === nativeExclude.toLowerCase()
                   );
@@ -56,7 +56,7 @@ function createRule(description, errorMessage, isViolation) {
           findRelevantNodes(context, node.value.expression).forEach(function (
             node
           ) {
-            if (isViolation(node, nativeExcludes)) {
+            if (isViolation(node)) {
               violationFound = true;
               context.report(node, errorMessage);
             }

--- a/tests/lib/rules/jsx-no-new-function-as-prop.js
+++ b/tests/lib/rules/jsx-no-new-function-as-prop.js
@@ -1,47 +1,47 @@
 "use strict";
 
 var invalidFunctionExpressions = [
-  { code: "<Item prop={function(){return true}} />", line: 1, column: 13 }
-].map(function({ code, line, column }) {
+  { code: "<Item prop={function(){return true}} />", line: 1, column: 13 },
+].map(function ({ code, line, column }) {
   return {
     code,
     errors: [
       {
         line,
         column,
-        type: "FunctionExpression"
-      }
-    ]
+        type: "FunctionExpression",
+      },
+    ],
   };
 });
 
 var invalidArrowFunctionExpressions = [
-  { code: "<Item prop={() => true} />", line: 1, column: 13 }
-].map(function({ code, line, column }) {
+  { code: "<Item prop={() => true} />", line: 1, column: 13 },
+].map(function ({ code, line, column }) {
   return {
     code,
     errors: [
       {
         line,
         column,
-        type: "ArrowFunctionExpression"
-      }
-    ]
+        type: "ArrowFunctionExpression",
+      },
+    ],
   };
 });
 
 var invalidNewExpressions = [
-  { code: "<Item prop={new Function('a', 'alert(a)')}/>", line: 1, column: 13 }
-].map(function({ code, line, column }) {
+  { code: "<Item prop={new Function('a', 'alert(a)')}/>", line: 1, column: 13 },
+].map(function ({ code, line, column }) {
   return {
     code,
     errors: [
       {
         line,
         column,
-        type: "NewExpression"
-      }
-    ]
+        type: "NewExpression",
+      },
+    ],
   };
 });
 
@@ -49,22 +49,22 @@ var invalidCallExpressions = [
   {
     code: "<Item onClick={this.clickHandler.bind(this)} />",
     line: 1,
-    column: 16
-  }
-].map(function({ code, line, column }) {
+    column: 16,
+  },
+].map(function ({ code, line, column }) {
   return {
     code,
     errors: [
       {
         line,
         column,
-        type: "CallExpression"
-      }
-    ]
+        type: "CallExpression",
+      },
+    ],
   };
 });
 
-var validExpressions = ["<Item onClick={bind(foo)} />"];
+var validExpressions = [{ code: "<Item onClick={bind(foo)} />" }];
 
 module.exports = require("../utils/common").testRule(
   "../../../lib/rules/jsx-no-new-function-as-prop",

--- a/tests/lib/utils/common.js
+++ b/tests/lib/utils/common.js
@@ -24,7 +24,7 @@ function testRule(
     { code: `<div style={${ruleCode}} />`, line: 1, column: 13 },
     {
       code: `<div style={${ruleCode}} />`,
-      options: [{ nativeExcludes: ["styleX"] }],
+      options: [{ nativeAllowList: ["styleX"] }],
       line: 1,
       column: 13,
     },
@@ -85,11 +85,11 @@ function testRule(
   valid = [
     {
       code: `<div style={${ruleCode}} />`,
-      options: [{ nativeExcludes: "all" }],
+      options: [{ nativeAllowList: "all" }],
     },
     {
       code: `<div style={${ruleCode}} />`,
-      options: [{ nativeExcludes: ["style"] }],
+      options: [{ nativeAllowList: ["style"] }],
     },
     { code: "<Item prop={0} />" },
     { code: "var a;<Item prop={a} />" },

--- a/tests/lib/utils/common.js
+++ b/tests/lib/utils/common.js
@@ -16,11 +16,18 @@ function testRule(
     ecmaVersion: 6,
     ecmaFeatures: {
       experimentalObjectRestSpread: true,
-      jsx: true
-    }
+      jsx: true,
+    },
   };
 
   invalid = [
+    { code: `<div style={${ruleCode}} />`, line: 1, column: 13 },
+    {
+      code: `<div style={${ruleCode}} />`,
+      options: [{ nativeExcludes: ["styleX"] }],
+      line: 1,
+      column: 13,
+    },
     { code: `<Item prop={${ruleCode}} />`, line: 1, column: 13 },
     { code: `<Item.tag prop={${ruleCode}} />`, line: 1, column: 17 },
     { code: `<Item prop={${ruleCode} || true} />`, line: 1, column: 13 },
@@ -36,12 +43,12 @@ function testRule(
     {
       code: `let a; a = ${ruleCode}; a = 1;<Item prop={a} />`,
       line: 1,
-      column: 12
+      column: 12,
     },
     {
       code: `let a; a = 1; a = ${ruleCode};<Item prop={a} />`,
       line: 1,
-      column: 19
+      column: 19,
     },
     {
       code: `function foo ({prop = ${ruleCode}}) {
@@ -49,7 +56,7 @@ function testRule(
     }
     `,
       line: 1,
-      column: 23
+      column: 23,
     },
     {
       code: `({prop = ${ruleCode}}) => {
@@ -57,58 +64,76 @@ function testRule(
     }
     `,
       line: 1,
-      column: 10
-    }
+      column: 10,
+    },
   ]
-    .map(function({ code, line, column }) {
+    .map(function ({ code, options = [], line, column }) {
       return {
         code,
+        options,
         errors: [
           {
             line,
             column,
-            type: ruleType
-          }
-        ]
+            type: ruleType,
+          },
+        ],
       };
     })
     .concat(invalid);
 
   valid = [
-    "<Item prop={0} />",
-    "var a;<Item prop={a} />",
-    "var a;a = 1;<Item prop={a} />",
-    "var a;a = a;<Item prop={a} />",
-    "var a;a = b;<Item prop={a} />",
-    `function foo ({prop1, prop2 = ${ruleCode}}) {
+    {
+      code: `<div style={${ruleCode}} />`,
+      options: [{ nativeExcludes: "all" }],
+    },
+    {
+      code: `<div style={${ruleCode}} />`,
+      options: [{ nativeExcludes: ["style"] }],
+    },
+    { code: "<Item prop={0} />" },
+    { code: "var a;<Item prop={a} />" },
+    { code: "var a;a = 1;<Item prop={a} />" },
+    { code: "var a;a = a;<Item prop={a} />" },
+    { code: "var a;a = b;<Item prop={a} />" },
+    {
+      code: `function foo ({prop1, prop2 = ${ruleCode}}) {
       return <Comp prop={prop1} />
     }`,
-    `function foo ({prop1 = ${ruleCode}, prop2}) {
+    },
+    {
+      code: `function foo ({prop1 = ${ruleCode}, prop2}) {
       return <Comp prop={prop2} />
     }`,
-    `({prop1, prop2 = ${ruleCode}}) => {
+    },
+    {
+      code: `({prop1, prop2 = ${ruleCode}}) => {
       return <Comp prop={prop1} />
     }`,
-    `({prop1 = ${ruleCode}, prop2}) => {
+    },
+    {
+      code: `({prop1 = ${ruleCode}, prop2}) => {
       return <Comp prop={prop2} />
-    }`
+    }`,
+    },
   ].concat(valid || []);
 
   new RuleTester().run(ruleName, rule, {
-    valid: valid.map(code => {
+    valid: valid.map(({ code, options = [] }) => {
       return {
         code,
-        parserOptions
+        options,
+        parserOptions,
       };
     }),
-    invalid: invalid.map(e => {
+    invalid: invalid.map((e) => {
       e.parserOptions = parserOptions;
       e.errors.message = errorMessage;
       return e;
-    })
+    }),
   });
 }
 
 module.exports = {
-  testRule
+  testRule,
 };


### PR DESCRIPTION
The first parameter each rule now accepts an object. The `nativeAllowList` can either be "all" or a string array of attribute names.