### PR TITLE
🐛 fix: trigger `jsx-no-jsx-as-prop` for react fragments

### DIFF
--- a/lib/rules/jsx-no-jsx-as-prop.js
+++ b/lib/rules/jsx-no-jsx-as-prop.js
@@ -4,6 +4,6 @@ module.exports = require("../utils/common").createRule(
   "Prevent JSX as JSX prop value",
   "JSX attribute values should not contain other JSX",
   function(node) {
-    return node.type === "JSXElement";
+    return ["JSXElement", "JSXFragment"].includes(node.type);
   }
 );

--- a/tests/lib/rules/jsx-no-jsx-as-prop.js
+++ b/tests/lib/rules/jsx-no-jsx-as-prop.js
@@ -16,11 +16,26 @@ var invalidJSXElements = [
   };
 });
 
+var invalidJSXFragments = [
+  { code: "<Item prop={<>SubItem</>} />", line: 1, column: 13 },
+].map(function ({ code, line, column }) {
+  return {
+    code,
+    errors: [
+      {
+        line,
+        column,
+        type: "JSXFragment",
+      },
+    ],
+  };
+});
+
 module.exports = testRule(
   "../../../lib/rules/jsx-no-jsx-as-prop",
   "jsx-no-jsx-as-prop",
   "JSX attribute values should not contain other JSX",
   "<SubItem />",
   "JSXElement",
-  [].concat(invalidJSXElements)
+  [].concat(invalidJSXElements, invalidJSXFragments)
 );


### PR DESCRIPTION
Fix #71 