### PR TITLE
🐛 fix: remove jsx-no-jsx-as-prop from recommended list on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ The rules enabled in this configuration are:
 - [react-perf/jsx-no-new-object-as-prop](docs/rules/jsx-no-new-object-as-prop.md)
 - [react-perf/jsx-no-new-array-as-prop](docs/rules/jsx-no-new-array-as-prop.md)
 - [react-perf/jsx-no-new-function-as-prop](docs/rules/jsx-no-new-function-as-prop.md)
-- [react-perf/jsx-no-jsx-as-prop](docs/rules/jsx-no-jsx-as-prop.md)
 
 ## All
 


### PR DESCRIPTION
- fix #55 